### PR TITLE
Implementing atom typing for OPLSAA that were overlooked

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,19 @@
 History
 =======
 
+2023.9.8 -- Added more typing for OPLS-AA
+  * cyclopropane -CH2-, -CHR-, and -CR2-
+  * hexafluorobenzene
+  * difluorobenzene
+  * bromobenzene
+  * iodobenzene
+  * thiophenol
+  * alkyl nitriles
+  * nitroalkanes
+  * nitrobenzene
+  * methylene in phenylacetonitrile
+  * corrections to methylene nitrile anion
+
 2023.9.7 -- Added typing in OPLS_AA for fluorobenzene
 
 2023.9.6 -- Fixed issue with PF6- geometry

--- a/forcefield_step/data/oplsaa.frc
+++ b/forcefield_step/data/oplsaa.frc
@@ -766,7 +766,7 @@
 2023.01.29    1  opls_707   12.011  C      4    Nitroalkane R3C-NO2
 2023.01.29    1  opls_708   14.007  N      3    Nitrobenzene -NO2
 2023.01.29    1  opls_709   12.011  C      3    Nitrobenzene C-NO2
-2023.01.29    1  opls_710   12.011  C      0    Benzonitrile -CH2-
+2023.01.29    1  opls_710   12.011  C      0    Benzonitrile -CH2- (phenylacetonitrile?)
 2023.01.29    1  opls_711   14.007  N      2    Neutral Benzamidine N
 2023.01.29    1  opls_712   15.999  O      1    Propylene Carbonate C=O
 2023.01.29    1  opls_713   12.011  C      3    Propylene Carbonate C=O
@@ -7531,7 +7531,7 @@
     "opls_363": {
         "2023.01.29": {
             "smarts": [
-                "[CD3-:1][CD2]~[ND1]"
+                "[CD3H2-:1][CD2]~[ND1]"
             ],
             "description": "Nitrile anion: methyl carbon -- CH2(-)-CN",
             "overrides": []
@@ -9228,6 +9228,33 @@
             "overrides": []
         }
     },
+    "opls_652": {
+        "2023.09.08": {
+            "smarts": [
+	    	"C1[CD4H2:1]C1"
+            ],
+            "description": "cyclopropane -CH2-",
+            "overrides": []
+        }
+    },
+    "opls_653": {
+        "2023.09.08": {
+            "smarts": [
+	    	"C1[CD4H1z0:1]C1"
+            ],
+            "description": "cyclopropane -CHR-",
+            "overrides": []
+        }
+    },
+    "opls_654": {
+        "2023.09.08": {
+            "smarts": [
+	    	"C1[CD4H0z0:1]C1"
+            ],
+            "description": "cyclopropane -CR2-",
+            "overrides": []
+        }
+    },
     "opls_659": {
         "2023.09.07": {
             "smarts": [
@@ -9243,6 +9270,249 @@
 	    	"c[F:1]"
             ],
             "description": "fluorine in fluorobenzene",
+            "overrides": []
+        }
+    },
+    "opls_661": {
+        "2023.09.08": {
+            "smarts": [
+	    	"[c:1]1(F)[c:2](F)[c:3](F)[c:4](F)[c:5](F)[c:6]1F"
+            ],
+            "description": "aromatic carbon in hexafluorobenzene",
+            "overrides": []
+        }
+    },
+    "opls_662": {
+        "2023.09.08": {
+            "smarts": [
+	    	"c1([F:1])c([F:2])c([F:3])c([F:4])c([F:5])c1[F:6]"
+            ],
+            "description": "fluorine in hexafluorobenzene",
+            "overrides": []
+        }
+    },
+    "opls_668": {
+        "2023.09.08": {
+            "smarts": [
+	    	"[cz0][c:1](F)[c:2](F)[cz0]"
+            ],
+            "description": "aromatic carbon in difluorobenzene",
+            "overrides": []
+        }
+    },
+    "opls_669": {
+        "2023.09.08": {
+            "smarts": [
+	    	"[cz0]c([F:1])c([F:2])[cz0]"
+            ],
+            "description": "fluorine in difluorobenzene",
+            "overrides": []
+        }
+    },
+    "opls_670": {
+        "2023.09.08": {
+            "smarts": [
+	    	"[c:1]Br"
+            ],
+            "description": "aromatic carbon in bromobenzene",
+            "overrides": []
+        }
+    },
+    "opls_671": {
+        "2023.09.08": {
+            "smarts": [
+	    	"c[Br:1]"
+            ],
+            "description": "bromine in bromobenzene",
+            "overrides": []
+        }
+    },
+    "opls_672": {
+        "2023.09.08": {
+            "smarts": [
+	    	"[c:1]I"
+            ],
+            "description": "aromatic carbon in iodobenzene",
+            "overrides": []
+        }
+    },
+    "opls_673": {
+        "2023.09.08": {
+            "smarts": [
+	    	"c[I:1]"
+            ],
+            "description": "iodine in iodobenzene",
+            "overrides": []
+        }
+    },
+    "opls_675": {
+        "2023.09.08": {
+            "smarts": [
+	    	"c[SH1:1]"
+            ],
+            "description": "S in thiophenol",
+            "overrides": []
+        }
+    },
+    "opls_676": {
+        "2023.09.08": {
+            "smarts": [
+	    	"[c:1][SH1]"
+            ],
+            "description": "aromatic carbon in thiophenol",
+            "overrides": []
+        }
+    },
+    "opls_694": {
+        "2023.09.08": {
+            "smarts": [
+	    	"[CD4][Cz1]#[N:1]"
+            ],
+            "description": "N in alkyl nitrile",
+            "overrides": []
+        }
+    },
+    "opls_695": {
+        "2023.09.08": {
+            "smarts": [
+	    	"[CD4][Cz1:1]#N"
+            ],
+            "description": "C in alkyl nitrile",
+            "overrides": []
+        }
+    },
+    "opls_696": {
+        "2023.09.08": {
+            "smarts": [
+	    	"[CH3:1]C#N"
+            ],
+            "description": "methyl carbon in acetonitrile",
+            "overrides": []
+        }
+    },
+    "opls_697": {
+        "2023.09.08": {
+            "smarts": [
+	    	"[CD4H2z0:1]C#N"
+            ],
+            "description": "methylene carbon in alkyl nitrile",
+            "overrides": []
+        }
+    },
+    "opls_698": {
+        "2023.09.08": {
+            "smarts": [
+	    	"[CD4Hz0:1]C#N"
+            ],
+            "description": "methine carbon in alkyl nitrile",
+            "overrides": []
+        }
+    },
+    "opls_699": {
+        "2023.09.08": {
+            "smarts": [
+	    	"[CD4H0z0:1]C#N"
+            ],
+            "description": "quaternary carbon in alkyl nitrile",
+            "overrides": []
+        }
+    },
+    "opls_700": {
+        "2023.09.08": {
+            "smarts": [
+	    	"[H:1][CD4z0]C#N"
+            ],
+            "description": "hydrogen adjacent to alkyl nitrile",
+            "overrides": []
+        }
+    },
+    "opls_701": {
+        "2023.09.08": {
+            "smarts": [
+	    	"[CD4z1][ND3:1](~[OD1])~[OD1]"
+            ],
+            "description": "N in nitroalkane",
+            "overrides": []
+        }
+    },
+    "opls_702": {
+        "2023.09.08": {
+            "smarts": [
+	    	"[ND3](~[OD1:1])~[OD1:2]"
+            ],
+            "description": "O in nitroalkane",
+            "overrides": []
+        }
+    },
+    "opls_703": {
+        "2023.09.08": {
+            "smarts": [
+	    	"[CH3:1][ND3](~[OD1])~[OD1]"
+            ],
+            "description": "C in nitromethane",
+            "overrides": []
+        }
+    },
+    "opls_704": {
+        "2023.09.08": {
+            "smarts": [
+	    	"[H:1][CD4z1][ND3](~[OD1])~[OD1]"
+            ],
+            "description": "H adjacent to nitro group",
+            "overrides": []
+        }
+    },
+    "opls_705": {
+        "2023.09.08": {
+            "smarts": [
+	    	"[CD4H2:1][ND3](~[OD1])~[OD1]"
+            ],
+            "description": "methylene adjacent to nitro group",
+            "overrides": []
+        }
+    },
+    "opls_706": {
+        "2023.09.08": {
+            "smarts": [
+	    	"[CD4H1:1][ND3](~[OD1])~[OD1]"
+            ],
+            "description": "methine adjacent to nitro group",
+            "overrides": []
+        }
+    },
+    "opls_707": {
+        "2023.09.08": {
+            "smarts": [
+	    	"[CD4H0:1][ND3](~[OD1])~[OD1]"
+            ],
+            "description": "quaternary carbon adjacent to nitro group",
+            "overrides": []
+        }
+    },
+    "opls_708": {
+        "2023.09.08": {
+            "smarts": [
+	    	"[cD3][ND3:1](~[OD1])~[OD1]"
+            ],
+            "description": "N in nitrobenzene",
+            "overrides": []
+        }
+    },
+    "opls_709": {
+        "2023.09.08": {
+            "smarts": [
+	    	"[cD3:1][ND3](~[OD1])~[OD1]"
+            ],
+            "description": "aromatic C in nitrobenzene",
+            "overrides": []
+        }
+    },
+    "opls_710": {
+        "2023.09.08": {
+            "smarts": [
+	    	"[cD3][CD4:1][CD2]#[ND1]"
+            ],
+            "description": "C in benzonitrile -- phenylacetonitrile?",
             "overrides": []
         }
     },
@@ -9715,7 +9985,7 @@
     "opls_790": {
         "2023.01.29": {
             "smarts": [
-                "[CD4H0:1]F"
+                "[CD4H0z1:1]F"
             ],
             "description": "Fluorinated methine R3CF",
             "overrides": []
@@ -9785,6 +10055,33 @@
                 "[H:1][CD4H1](c)(F)F"
             ],
             "description": "difluoromethylbenzene: hydrogen Ar-CHF2",
+            "overrides": []
+        }
+    },
+    "opls_665": {
+        "2023.09.08": {
+            "smarts": [
+	    	"c1cccc[c:1]1C(F)(F)F"
+            ],
+            "description": "phenyl carbon in trifluoromethylbenzene",
+            "overrides": []
+        }
+    },
+    "opls_666": {
+        "2023.09.08": {
+            "smarts": [
+	    	"c1ccccc1[C:1](F)(F)F"
+            ],
+            "description": "methyl carbon in trifluoromethylbenzene",
+            "overrides": []
+        }
+    },
+    "opls_667": {
+        "2023.09.08": {
+            "smarts": [
+	    	"c1ccccc1C([F:1])([F:2])[F:3]"
+            ],
+            "description": "fluorine in trifluoromethylbenzene",
             "overrides": []
         }
     },

--- a/tests/test_oplsaa_assignment.py
+++ b/tests/test_oplsaa_assignment.py
@@ -1882,18 +1882,6 @@ if True:
             print(f"Incorrect typing. Should be:\n  {correct}\nnot\n  {result}")
             raise AssertionError(f"\n result: {result}\ncorrect: {correct}")
 
-        # Ethylnitrile anion
-        correct = (
-            ["opls_80", "opls_363", "opls_365", "opls_366"]
-            + 3 * ["opls_85"]
-            + ["opls_364"]
-        )
-        configuration.from_smiles("C[CH-]C#N")
-        result = oplsaa_assigner.assign(configuration)
-        if result != correct:
-            print(f"Incorrect typing. Should be:\n  {correct}\nnot\n  {result}")
-            raise AssertionError(f"\n result: {result}\ncorrect: {correct}")
-
     def test_opls_376(oplsaa_assigner, configuration):
         """Test of atom-type assignment for hydroxide anion OH(-)
         opls 376, O
@@ -2661,13 +2649,282 @@ if True:
             print(f"Incorrect typing. Should be:\n  {correct}\nnot\n  {result}")
             raise AssertionError(f"\n result: {result}\ncorrect: {correct}")
 
+    def test_opls_652(oplsaa_assigner, configuration):
+        """Test of atom-type assignment for
+        opls 652, cyclopropane -CH2-
+        opls 653, cyclopropane -CHR-
+        opls 654, cyclopropane -CR2-
+        """
+        correct = [
+            "opls_652",
+            "opls_653",
+            "opls_80",
+            "opls_654",
+            "opls_80",
+            "opls_80",
+        ] + 12 * ["opls_85"]
+        configuration.from_smiles("C1C(C)C1(C)(C)")
+        result = oplsaa_assigner.assign(configuration)
+        if result != correct:
+            print(f"Incorrect typing. Should be:\n  {correct}\nnot\n  {result}")
+            raise AssertionError(f"\n result: {result}\ncorrect: {correct}")
+
     def test_opls_659(oplsaa_assigner, configuration):
         """Test of atom-type assignment for
         opls 659, aromatic carbon in fluorobenzene
-        opls 660, chlorine in fluorobenzene
+        opls 660, fluorine in fluorobenzene
         """
         correct = ["opls_660", "opls_659"] + 5 * ["opls_90"] + 5 * ["opls_91"]
         configuration.from_smiles("Fc1ccccc1")
+        result = oplsaa_assigner.assign(configuration)
+        if result != correct:
+            print(f"Incorrect typing. Should be:\n  {correct}\nnot\n  {result}")
+            raise AssertionError(f"\n result: {result}\ncorrect: {correct}")
+
+    def test_opls_661(oplsaa_assigner, configuration):
+        """Test of atom-type assignment for
+        opls 661, aromatic carbon in hexafluorobenzene
+        opls 662, chlorine in hexafluorobenzene
+        """
+        correct = 6 * ["opls_661", "opls_662"]
+        configuration.from_smiles("c1(F)c(F)c(F)c(F)c(F)c1(F)")
+        result = oplsaa_assigner.assign(configuration)
+        if result != correct:
+            print(f"Incorrect typing. Should be:\n  {correct}\nnot\n  {result}")
+            raise AssertionError(f"\n result: {result}\ncorrect: {correct}")
+
+    def test_opls_665(oplsaa_assigner, configuration):
+        """Test of atom-type assignment for
+        opls 665, aromatic carbon in trifluoromethylbenzene
+        opls 666, methyl carbon in trifluoromethylbenzene
+        opls 667, fluorine in trifluoromethylbenzene
+        """
+        correct = (
+            5 * ["opls_90"]
+            + ["opls_665", "opls_666"]
+            + 3 * ["opls_667"]
+            + 5 * ["opls_91"]
+        )
+        configuration.from_smiles("c1ccccc1C(F)(F)F")
+        result = oplsaa_assigner.assign(configuration)
+        if result != correct:
+            print(f"Incorrect typing. Should be:\n  {correct}\nnot\n  {result}")
+            raise AssertionError(f"\n result: {result}\ncorrect: {correct}")
+
+    def test_opls_668(oplsaa_assigner, configuration):
+        """Test of atom-type assignment for
+        opls 668, aromatic carbon in difluorobenzene
+        opls 669, chlorine in difluorobenzene
+        """
+        correct = 2 * ["opls_668", "opls_669"] + 4 * ["opls_90"] + 4 * ["opls_91"]
+        configuration.from_smiles("c1(F)c(F)cccc1")
+        result = oplsaa_assigner.assign(configuration)
+        if result != correct:
+            print(f"Incorrect typing. Should be:\n  {correct}\nnot\n  {result}")
+            raise AssertionError(f"\n result: {result}\ncorrect: {correct}")
+
+    def test_opls_670(oplsaa_assigner, configuration):
+        """Test of atom-type assignment for
+        opls 670, aromatic carbon in bromobenzene
+        opls 671, bromine in bromobenzene
+        """
+        correct = ["opls_671", "opls_670"] + 5 * ["opls_90"] + 5 * ["opls_91"]
+        configuration.from_smiles("Brc1ccccc1")
+        result = oplsaa_assigner.assign(configuration)
+        if result != correct:
+            print(f"Incorrect typing. Should be:\n  {correct}\nnot\n  {result}")
+            raise AssertionError(f"\n result: {result}\ncorrect: {correct}")
+
+    def test_opls_672(oplsaa_assigner, configuration):
+        """Test of atom-type assignment for
+        opls 672, aromatic carbon in iodobenzene
+        opls 673, fluorine in iodobenzene
+        """
+        correct = ["opls_673", "opls_672"] + 5 * ["opls_90"] + 5 * ["opls_91"]
+        configuration.from_smiles("Ic1ccccc1")
+        result = oplsaa_assigner.assign(configuration)
+        if result != correct:
+            print(f"Incorrect typing. Should be:\n  {correct}\nnot\n  {result}")
+            raise AssertionError(f"\n result: {result}\ncorrect: {correct}")
+
+    def test_opls_675(oplsaa_assigner, configuration):
+        """Test of atom-type assignment for
+        opls 676, aromatic carbon in thiophenol
+        opls 675, sulfur in thiophenol
+        """
+        correct = (
+            ["opls_675", "opls_676"] + 5 * ["opls_90"] + ["opls_146"] + 5 * ["opls_91"]
+        )
+        configuration.from_smiles("Sc1ccccc1")
+        result = oplsaa_assigner.assign(configuration)
+        if result != correct:
+            print(f"Incorrect typing. Should be:\n  {correct}\nnot\n  {result}")
+            raise AssertionError(f"\n result: {result}\ncorrect: {correct}")
+
+    def test_opls_694(oplsaa_assigner, configuration):
+        """Test of atom-type assignment for
+        opls 695, carbon in alkyl nitrile
+        opls 694, nitrogen in alkyl nitrile
+        opls 696, methyl carbon in acetonitrile
+        opls 700, H adjacent to alkyl nitrile
+        """
+        correct = ["opls_694", "opls_695", "opls_696"] + 3 * ["opls_700"]
+        configuration.from_smiles("N#CC")
+        result = oplsaa_assigner.assign(configuration)
+        if result != correct:
+            print(f"Incorrect typing. Should be:\n  {correct}\nnot\n  {result}")
+            raise AssertionError(f"\n result: {result}\ncorrect: {correct}")
+
+    def test_opls_697(oplsaa_assigner, configuration):
+        """Test of atom-type assignment for
+        opls 695, carbon in alkyl nitrile
+        opls 694, nitrogen in alkyl nitrile
+        opls 697, methylene carbon in alkyl nitrile
+        opls 700, H adjacent to alkyl nitrile
+        """
+        correct = (
+            ["opls_694", "opls_695", "opls_697", "opls_80"]
+            + 2 * ["opls_700"]
+            + 3 * ["opls_85"]
+        )
+        configuration.from_smiles("N#CCC")
+        result = oplsaa_assigner.assign(configuration)
+        if result != correct:
+            print(f"Incorrect typing. Should be:\n  {correct}\nnot\n  {result}")
+            raise AssertionError(f"\n result: {result}\ncorrect: {correct}")
+
+    def test_opls_698(oplsaa_assigner, configuration):
+        """Test of atom-type assignment for
+        opls 695, carbon in alkyl nitrile
+        opls 694, nitrogen in alkyl nitrile
+        opls 698, methine carbon in alkyl nitrile
+        opls 700, H adjacent to alkyl nitrile
+        """
+        correct = (
+            ["opls_694", "opls_695", "opls_698"]
+            + 2 * ["opls_80"]
+            + ["opls_700"]
+            + 6 * ["opls_85"]
+        )
+        configuration.from_smiles("N#CC(C)C")
+        result = oplsaa_assigner.assign(configuration)
+        if result != correct:
+            print(f"Incorrect typing. Should be:\n  {correct}\nnot\n  {result}")
+            raise AssertionError(f"\n result: {result}\ncorrect: {correct}")
+
+    def test_opls_699(oplsaa_assigner, configuration):
+        """Test of atom-type assignment for
+        opls 695, carbon in alkyl nitrile
+        opls 694, nitrogen in alkyl nitrile
+        opls 698, quaternary carbon in alkyl nitrile
+        """
+        correct = (
+            ["opls_694", "opls_695", "opls_699"] + 3 * ["opls_80"] + 9 * ["opls_85"]
+        )
+        configuration.from_smiles("N#CC(C)(C)C")
+        result = oplsaa_assigner.assign(configuration)
+        if result != correct:
+            print(f"Incorrect typing. Should be:\n  {correct}\nnot\n  {result}")
+            raise AssertionError(f"\n result: {result}\ncorrect: {correct}")
+
+    def test_opls_701(oplsaa_assigner, configuration):
+        """Test of atom-type assignment for
+        opls 701, nitrogen in alkyl nitro group
+        opls 702, oxygen in alkyl nitro group
+        opls 703, methyl carbon in nitromethane
+        opls 704, H adjacent to alkyl nitro group
+        """
+        correct = ["opls_701", "opls_702", "opls_702", "opls_703"] + 3 * ["opls_704"]
+        configuration.from_smiles("N(=O)(=O)C")
+        result = oplsaa_assigner.assign(configuration)
+        if result != correct:
+            print(f"Incorrect typing. Should be:\n  {correct}\nnot\n  {result}")
+            raise AssertionError(f"\n result: {result}\ncorrect: {correct}")
+
+    def test_opls_705(oplsaa_assigner, configuration):
+        """Test of atom-type assignment for
+        opls 701, nitrogen in alkyl nitro group
+        opls 702, oxygen in alkyl nitro group
+        opls 705, methylene carbon adjacent to an nitro group
+        opls 704, H adjacent to alkyl nitro group
+        """
+        correct = (
+            ["opls_701", "opls_702", "opls_702", "opls_705", "opls_80"]
+            + 2 * ["opls_704"]
+            + 3 * ["opls_85"]
+        )
+        configuration.from_smiles("N(=O)(=O)CC")
+        result = oplsaa_assigner.assign(configuration)
+        if result != correct:
+            print(f"Incorrect typing. Should be:\n  {correct}\nnot\n  {result}")
+            raise AssertionError(f"\n result: {result}\ncorrect: {correct}")
+
+    def test_opls_706(oplsaa_assigner, configuration):
+        """Test of atom-type assignment for
+        opls 701, nitrogen in alkyl nitro group
+        opls 702, oxygen in alkyl nitro group
+        opls 706, methine carbon adjacent to an nitro group
+        opls 704, H adjacent to alkyl nitro group
+        """
+        correct = (
+            ["opls_701", "opls_702", "opls_702", "opls_706"]
+            + 2 * ["opls_80"]
+            + ["opls_704"]
+            + 6 * ["opls_85"]
+        )
+        configuration.from_smiles("N(=O)(=O)C(C)C")
+        result = oplsaa_assigner.assign(configuration)
+        if result != correct:
+            print(f"Incorrect typing. Should be:\n  {correct}\nnot\n  {result}")
+            raise AssertionError(f"\n result: {result}\ncorrect: {correct}")
+
+    def test_opls_707(oplsaa_assigner, configuration):
+        """Test of atom-type assignment for
+        opls 701, nitrogen in alkyl nitro group
+        opls 702, oxygen in alkyl nitro group
+        opls 707, quaternary carbon adjacent to an nitro group
+        opls 704, H adjacent to alkyl nitro group
+        """
+        correct = (
+            ["opls_701", "opls_702", "opls_702", "opls_707"]
+            + 3 * ["opls_80"]
+            + 9 * ["opls_85"]
+        )
+        configuration.from_smiles("N(=O)(=O)C(C)(C)C")
+        result = oplsaa_assigner.assign(configuration)
+        if result != correct:
+            print(f"Incorrect typing. Should be:\n  {correct}\nnot\n  {result}")
+            raise AssertionError(f"\n result: {result}\ncorrect: {correct}")
+
+    def test_opls_708(oplsaa_assigner, configuration):
+        """Test of atom-type assignment for
+        opls 708, nitrogen in nitrobenzene
+        opls 702, oxygen in nitro group
+        opls 709, aromatic carbon in nitrobenzene
+        """
+        correct = (
+            ["opls_708", "opls_702", "opls_702", "opls_709"]
+            + 5 * ["opls_90"]
+            + 5 * ["opls_91"]
+        )
+        configuration.from_smiles("N(=O)(=O)c1ccccc1")
+        result = oplsaa_assigner.assign(configuration)
+        if result != correct:
+            print(f"Incorrect typing. Should be:\n  {correct}\nnot\n  {result}")
+            raise AssertionError(f"\n result: {result}\ncorrect: {correct}")
+
+    def test_opls_710(oplsaa_assigner, configuration):
+        """Test of atom-type assignment for
+        opls 710, carbon in benzonitrile -- methylene in phenylacetonitrile?
+        opls 694, nitrogen in nitrile
+        """
+        correct = (
+            ["opls_694", "opls_695", "opls_710", "opls_163"]
+            + 5 * ["opls_90"]
+            + 2 * ["opls_700"]
+            + 5 * ["opls_91"]
+        )
+        configuration.from_smiles("N#CCc1ccccc1")
         result = oplsaa_assigner.assign(configuration)
         if result != correct:
             print(f"Incorrect typing. Should be:\n  {correct}\nnot\n  {result}")


### PR DESCRIPTION
Handling the following functional groups
  * cyclopropane -CH2-, -CHR-, and -CR2-
  * hexafluorobenzene
  * difluorobenzene
  * bromobenzene
  * iodobenzene
  * thiophenol
  * alkyl nitriles
  * nitroalkanes
  * nitrobenzene
  * methylene in phenylacetonitrile
  * corrections to methylene nitrile anion