### PR TITLE
Fixed bug in PF6- angle parameters

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,15 @@
 History
 =======
 
+2024.1.10 -- Fixed PF6- issue in CL&P forcefield
+  * The angle parameters for PF6- in the CL&P forcefield only work if the 180º F-P-F
+    angles are not included in the calculation. Replacing them with an equivalent
+    periodic SHAPES-like potential almost works; however, since 0º is a valid angle and
+    there are no 1-3 nonbonds, nothing keeps the F atoms apart. This is solved using a
+    tabulated potential based on the SHAPES potential but with an added 1-3 repulsion
+    large enough that the gradient is always pusing small angles apart, but not large
+    enough to affect the minimum at 90º.
+
 2023.9.14 -- Fixed errors! And added C2mim to test.
   * The units of the torsions were incorrect in the last implementation.
   * Added parameters for 1-alkyl-3-methylimidazolium cations from JCP 108, 2038 (2004)

--- a/forcefield_step/data/oplsaa.frc
+++ b/forcefield_step/data/oplsaa.frc
@@ -43,7 +43,8 @@
 2023.01.29   1    quadratic_bond                   CL&P
 2023.01.29   1    quadratic_angle                  CL&P
 2023.08.21   1    quadratic_angle                  CL&P
-2023.08.21   1    simple_fourier_angle             CL&P
+! 2023.08.21   1    simple_fourier_angle             CL&P
+2023.08.26   1    tabulated_angle                  CL&P
 2023.01.29   1    torsion_opls                     CL&P
 2023.01.29   1    templates                        CL&P
 #end
@@ -11000,7 +11001,7 @@
 
 ! Version   Ref   I         J         K           Theta0        K2
 !---------  ----  --------  --------  --------  --------  --------
-2023.01.29  3     FP        P         FP          90.0      1165.0
+! 2023.01.29  3     FP        P         FP          90.0      1165.0 replaced by tabulated form
 2023.09.13  3	  Sbt	    Nbt	      Sbt	 125.6	     671.0
 2023.09.13  3	  O	    N	      S       	 113.6	     789.0
 2023.09.13  5	  C	    S	      N       	 103.5	     764.0


### PR DESCRIPTION
The angle parameters for PF6- in the CL&P forcefield only work if the 180º F-P-F angles are not included in the calculation. Replacing them with an equivalent periodic SHAPES-like potential almost works; however, since 0º is a valid angle and there are no 1-3 nonbonds, nothing keeps the F atoms apart. This is solved using a tabulated potential based on the SHAPES potential but with an added 1-3 repulsion large enough that the gradient is always pusing small angles apart, but not large enough to affect the minimum at 90º.